### PR TITLE
Improve agent memory and add web fetching tool

### DIFF
--- a/memory.py
+++ b/memory.py
@@ -1,0 +1,41 @@
+import os
+import json
+
+class Memory:
+    """Simple persistent memory for agent conversations and results."""
+    def __init__(self, path: str = "agent_memory.json"):
+        self.path = path
+        self.data = {"history": [], "last_result": None, "last_image_path": None}
+        self._load()
+
+    def _load(self):
+        if os.path.exists(self.path):
+            try:
+                with open(self.path, 'r', encoding='utf-8') as f:
+                    self.data = json.load(f)
+            except Exception:
+                self.data = {"history": [], "last_result": None, "last_image_path": None}
+
+    def save(self):
+        try:
+            with open(self.path, 'w', encoding='utf-8') as f:
+                json.dump(self.data, f, ensure_ascii=False, indent=2)
+        except Exception:
+            pass
+
+    # ---- History helpers ----
+    def add_message(self, role: str, content: str):
+        self.data.setdefault("history", []).append({"role": role, "content": content})
+        self.save()
+
+    def get_history(self):
+        return self.data.get("history", [])
+
+    # ---- Result helpers ----
+    def set_last_result(self, result_text: str, image_path: str):
+        self.data["last_result"] = result_text
+        self.data["last_image_path"] = image_path
+        self.save()
+
+    def get_last_result(self):
+        return self.data.get("last_result"), self.data.get("last_image_path")


### PR DESCRIPTION
## Summary
- add `memory.py` for persistent conversation memory
- support fetching webpage text via new `fetch_web_content` tool
- wire memory throughout agent execution functions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685522ee9de88326b8fe3d4c0718d05b